### PR TITLE
feat: generate new sd card image on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,29 @@ run dfu_nand
 ## First boot ##
 
 The first time your board boots, it will take a long while, but this is perfectly normal. Linux has to fix up the filesystem and prepare for boot at the same time. Subsequent reboots should be faster.
+
+## Flash SD card ##
+
+### Required tools ###
+
+To flash an sdcard, you can use [Imager](https://www.raspberrypi.com/software/) (recommended) or use the commandline instructions below.
+
+
+Plug in the sdcard into the sdcard reader and plug into host machine.
+
+Check device is mounted with
+```
+df -h
+```
+
+If it's not mounted, you can mount with
+```
+mount /dev/[sdcard_device] /mnt
+```
+
+Take note of the device the sdcard is mounted under.
+
+Flash the sdcard with 
+```
+sudo dd if=/path/to/buildroot/output/speedsaver/images/sysimage-sdcard.img of=/dev/[sdcard_device] bs=1m
+```

--- a/board/allwinner/suniv-f1c100s/genimage-sdcard.cfg
+++ b/board/allwinner/suniv-f1c100s/genimage-sdcard.cfg
@@ -1,0 +1,31 @@
+image bootfs.vfat {
+	vfat {
+		files = {
+			"zImage",
+			"u-boot.bin",
+			"devicetree.dtb",
+		}
+	}
+	size = 8M
+}
+
+image sysimage-sdcard.img {
+	hdimage {}
+
+	partition u-boot {
+		image = "u-boot-sunxi-with-spl.bin"
+		offset = 0x2000
+		size = 1016K # 1MB - 8192
+	}
+
+	partition boot {
+		partition-type = 0xC
+		bootable = "true"
+		image = "bootfs.vfat"
+	}
+
+	partition rootfs {
+		partition-type = 0x83
+		image = "rootfs.ubi"
+	}
+}

--- a/board/allwinner/suniv-f1c100s/scripts/genimage.sh
+++ b/board/allwinner/suniv-f1c100s/scripts/genimage.sh
@@ -10,3 +10,4 @@ SELFDIR=`dirname \`realpath ${0}\``
 
 ${SELFDIR}/mknanduboot.sh ${1}/${2} ${1}/u-boot-sunxi-with-nand-spl.bin
 support/scripts/genimage.sh ${1} -c "${BR2_EXTERNAL_SPEEDSAVER_MANGOPI_PATH}/board/allwinner/suniv-f1c100s/genimage-nand.cfg"
+support/scripts/genimage.sh ${1} -c "${BR2_EXTERNAL_SPEEDSAVER_MANGOPI_PATH}/board/allwinner/suniv-f1c100s/genimage-sdcard.cfg"

--- a/board/allwinner/suniv-f1c100s/uboot.env
+++ b/board/allwinner/suniv-f1c100s/uboot.env
@@ -1,12 +1,18 @@
 bootargs=console=ttyS1,115200n8 earlyprintk mtdparts=spi0.0:1m(u-boot),-(rootfs) ubi.mtd=1 root=ubi0:rootfs rootfstype=ubifs rw quiet systemd.gpt_auto=no systemd.log_color=off
 bootargs_common=console=ttyS0,115200 earlyprintk rootwait consoleblank=0
 
+mmc_kernel=zImage
+mmc_fdt=devicetree.dtb
+mmc_ubootpart=1
+mmc_bootpart=2
+mmc_rootpart=3
+
 stderr=serial
 stdin=serial
 stdout=serial
 kernel_addr_r=0x80000000
 fdt_addr_r=0x80700000
-bootm_size=0x1700000
+bootm_size=0x1800000
 
 boot_slot_0=empty
 boot_slot_1=empty
@@ -31,12 +37,16 @@ genbootargs=setenv bootargs ${bootargs_common}  root=/dev/mmcblk0p3;
 
 fel_boot=echo "Booting from FEL..."; rootdev=/dev/ram0; run genbootargs; bootz ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r};
 nand_boot=echo "Booting from SPI-NAND..."; ubi part rootfs; ubifsmount ubi0:rootfs; ubifsload ${kernel_addr_r} /boot/zImage; ubifsload ${fdt_addr_r} /boot/devicetree.dtb; bootz ${kernel_addr_r} - ${fdt_addr_r};
+mmc_boot=mmc dev ${devnum}; echo "Booting from MMC${devnum}..."; load mmc ${devnum}:${mmc_bootpart} ${kernel_addr_r} ${mmc_kernel}; load mmc ${devnum}:${mmc_bootpart} ${fdt_addr_r} ${mmc_fdt}; bootz ${kernel_addr_r} - ${fdt_addr_r};
 
 bootcmd_fel=if test "${boot_device}" = "fel"; then run fel_boot; fi;
 bootcmd_flasher=if test "${boot_device}" = "mmc0"; then run flasher_boot; fi;
 bootcmd_spi=if test "${boot_device}" = "spi"; then run nand_boot; fi;
+bootcmd_mmc0=if test "${boot_device}" = "mmc0"; then devnum=0; run mmc_boot; fi;
+bootcmd_mmc1=if test "${boot_device}" = "mmc1"; then devnum=1; run mmc_boot; fi;
+bootcmd_dfu=if test "${boot_device}" = "dfu"; then run dfu_boot; if;
 
-boot_targets=fel dfu flasher spi
+boot_targets=fel dfu mmc0 mmc1 flasher spi
 bootcmd=run scan_boot_slot; for target in ${boot_targets}; do run bootcmd_${target}; done
 
 mtdparts=spi-nand0:1m(u-boot),-(rootfs)


### PR DESCRIPTION
Other notes:

- If running buildroot again, you may want to force that buildroot to rebuild the u-boot package.


Inside `output/speedsaver` directory

`make uboot-reconfigure`
`make`